### PR TITLE
fix: allow query param in config gtfsRtTripupdatesUrl

### DIFF
--- a/public/js/transit-departures-widget.js
+++ b/public/js/transit-departures-widget.js
@@ -6,6 +6,7 @@ function setupTransitDeparturesWidget(routes, stops, config) {
   let departuresTimeout
   let initialStop
   let selectedParameters
+  let url = new URL(config.gtfsRtTripupdatesUrl)
 
   function updateUrlWithStop(stop) {
     const url = new URL(window.location.origin + window.location.pathname)
@@ -15,7 +16,7 @@ function setupTransitDeparturesWidget(routes, stops, config) {
   }
 
   async function fetchTripUpdates() {
-    const url = `${config.gtfsRtTripupdatesUrl}?cacheBust=${Date.now()}`
+    url.searchParams.append('cacheBust', Date.now())
     const response = await fetch(url)
     if (response.ok) {
       const bufferResponse = await response.arrayBuffer()


### PR DESCRIPTION
hello :) 

here is small change to allow base gtfs_rt_tripupdates_url to contain url params.
otherwise it will just create myurl?param1=yes?cachbust=12  which won't work :) 

Hope this helps 

